### PR TITLE
Rudimentary table support

### DIFF
--- a/HtmlTextView/build.gradle
+++ b/HtmlTextView/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 7
         targetSdkVersion 22
-        versionCode 4
-        versionName '1.3'
+        versionCode 5
+        versionName '1.4'
     }
 }
 
@@ -17,7 +17,7 @@ publish {
     userOrg = 'sufficientlysecure'
     groupId = 'org.sufficientlysecure'
     artifactId = 'html-textview'
-    version = '1.3'
+    version = '1.4'
     description = 'HtmlTextView is an extended TextView component for Android, which can load HTML and converts it into Spannable for displaying it.'
     website = 'https://github.com/sufficientlysecure/html-textview'
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/ClickableTableSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/ClickableTableSpan.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2016 Richard Thai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sufficientlysecure.htmltextview;
+
+import android.text.style.ClickableSpan;
+
+/**
+ * This span defines what should happen if a table is clicked. This abstract class is defined so
+ * that applications can access the raw table HTML and do whatever they'd like to render it (e.g.
+ * show it in a WebView).
+ */
+public abstract class ClickableTableSpan extends ClickableSpan {
+    protected String mTableHtml;
+
+    // This sucks, but we need this so that each table can get its own ClickableTableSpan.
+    // Otherwise, we end up removing the clicking from earlier tables.
+    public abstract ClickableTableSpan newInstance();
+
+    public void setTableHtml(String tableHtml) {
+        this.mTableHtml = tableHtml;
+    }
+
+    public String getTableHtml() {
+        return mTableHtml;
+    }
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DrawTableLinkSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DrawTableLinkSpan.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2016 Richard Thai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.sufficientlysecure.htmltextview;
+
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.text.style.ReplacementSpan;
+
+/**
+ * This span defines how a table should be rendered in the HtmlTextView. The default implementation
+ * is a cop-out which replaces the HTML table with some text ("[tap for table]" is the default).
+ *
+ * This is to be used in conjunction with the ClickableTableSpan which will redirect a click to the
+ * text some application-defined action (i.e. render the raw HTML in a WebView).
+ */
+public class DrawTableLinkSpan extends ReplacementSpan {
+    private int mWidth;
+
+    private static final String DEFAULT_TABLE_LINK_TEXT = "";
+    private static float DEFAULT_TEXT_SIZE = 80f;
+    private static int DEFAULT_TEXT_COLOR = Color.BLUE;
+
+    protected String mTableLinkText = DEFAULT_TABLE_LINK_TEXT;
+    protected float mTextSize = DEFAULT_TEXT_SIZE;
+    protected int mTextColor = DEFAULT_TEXT_COLOR;
+
+    // This sucks, but we need this so that each table can get drawn.
+    // Otherwise, we end up with the default table link text (nothing) for earlier tables.
+    public DrawTableLinkSpan newInstance() {
+        final DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
+        drawTableLinkSpan.setTableLinkText(mTableLinkText);
+        drawTableLinkSpan.setTextSize(mTextSize);
+        drawTableLinkSpan.setTextColor(mTextColor);
+
+        return drawTableLinkSpan;
+    }
+
+    @Override
+    public int getSize(Paint paint, CharSequence text, int start, int end, Paint.FontMetricsInt fm) {
+        mWidth = (int) paint.measureText(mTableLinkText, 0, mTableLinkText.length());
+        mTextSize = paint.getTextSize();
+        return mWidth;
+    }
+
+    @Override
+    public void draw(Canvas canvas, CharSequence text, int start, int end, float x, int top, int y, int bottom, Paint paint) {
+        final Paint paint2 = new Paint();
+        paint2.setStyle(Paint.Style.STROKE);
+        paint2.setColor(mTextColor);
+        paint2.setAntiAlias(true);
+        paint2.setTextSize(mTextSize);
+
+        canvas.drawText(mTableLinkText, x, bottom, paint2);
+    }
+
+    public void setTableLinkText(String tableLinkText) {
+        this.mTableLinkText = tableLinkText;
+    }
+
+    public void setTextSize(float textSize) {
+        this.mTextSize = textSize;
+    }
+
+    public void setTextColor(int textColor) {
+        this.mTextColor = textColor;
+    }
+
+    public String getTableLinkText() {
+        return mTableLinkText;
+    }
+
+    public float getTextSize() {
+        return mTextSize;
+    }
+
+    public int getTextColor() {
+        return mTextColor;
+    }
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -31,6 +31,8 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
     public static final boolean DEBUG = false;
     boolean mDontConsumeNonUrlClicks = true;
     boolean mLinkHit;
+    private ClickableTableSpan mClickableTableSpan;
+    private DrawTableLinkSpan mDrawTableLinkSpan;
 
     public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
@@ -113,13 +115,13 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         }
 
         // this uses Android's Html class for basic parsing, and HtmlTagHandler
-        setText(Html.fromHtml(html, htmlImageGetter, new HtmlTagHandler()));
+        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
+        htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
+        htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
+        setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
 
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());
-
-        // no flickering when clicking textview for Android < 4, but overriders color...
-//        text.setTextColor(getResources().getColor(android.R.color.secondary_text_dark_nodisable));
     }
 
     /**
@@ -144,4 +146,11 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         }
     }
 
+    public void setClickableTableSpan(ClickableTableSpan clickableTableSpan) {
+        this.mClickableTableSpan = clickableTableSpan;
+    }
+
+    public void setDrawTableLinkSpan(DrawTableLinkSpan drawTableLinkSpan) {
+        this.mDrawTableLinkSpan = drawTableLinkSpan;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.sufficientlysecure:html-textview:1.3'
+    compile 'org.sufficientlysecure:html-textview:1.4'
 }
 ```
 
@@ -89,6 +89,24 @@ text.setHtmlFromRawResource(this, R.raw.help, new RemoteImageGetter());
 * ``<center>``
 * ``<strike>``
 
+### Support for HTML tables
+HtmlTextView now supports HTML tables (to a limited extent) by condensing the text into a link which developers are able to render in a native WebView. To take advantage of the feature you'll need to:
+
+1. implement a `ClickableTableSpan` which provides access to the table HTML (which can be forwarded to a WebView)
+
+2. provide a `DrawTableLinkSpan` which defines what the table link should look like (i.e. text, text color, text size)
+
+Take a look at the project's [sample app](https://github.com/SufficientlySecure/html-textview/blob/master/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java) for an example.
+
+We recognize the standard table tags:
+
+* ``<table>``
+* ``<tr>``
+* ``<th>``
+* ``<td>``
+
+as well as the tags extended by HtmlTextView. However, support doesn’t currently extend to tags natively supported by Android (e.g. ``<b>``, ``<big>``, ``<h1>``) which means tables will not include the extra styling.
+
 ## License
 Apache License v2
 
@@ -100,6 +118,7 @@ See LICENSE for full license text.
 - Original [HtmlRemoteImageGetter](https://gist.github.com/Antarix/4167655) developed by Antarix Tandon
 - Original [HtmlLocalImageGetter](http://stackoverflow.com/a/22298833) developed by drawk
 - [JellyBeanSpanFixTextView](https://gist.github.com/pyricau/3424004) (with fix from comment) developed by Pierre-Yves Ricau
+- [Table support](https://github.com/SufficientlySecure/html-textview/pull/33) added by Richard Thai
 
 ## Contributions
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "org.sufficientlysecure.htmltextview.example"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -15,4 +15,5 @@ android {
 
 dependencies {
     compile project(':HtmlTextView')
+    compile 'com.android.support:appcompat-v7:23.1.1'
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".WebViewActivity" android:theme="@style/Theme.AppCompat.NoActionBar"/>
     </application>
 
 </manifest>

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -1,20 +1,107 @@
 package org.sufficientlysecure.htmltextview.example;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 
+import org.sufficientlysecure.htmltextview.ClickableTableSpan;
+import org.sufficientlysecure.htmltextview.DrawTableLinkSpan;
 import org.sufficientlysecure.htmltextview.HtmlTextView;
 
+import static org.sufficientlysecure.htmltextview.example.WebViewActivity.EXTRA_TABLE_HTML;
+
 public class MainActivity extends Activity {
+
+    // The html table(s) are individually passed through to the ClickableTableSpan implementation
+    // presumably for a WebView activity.
+    class ClickableTableSpanImpl extends ClickableTableSpan {
+        @Override
+        public ClickableTableSpan newInstance() {
+            return new ClickableTableSpanImpl();
+        }
+
+        @Override
+        public void onClick(View widget) {
+            Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
+            intent.putExtra(EXTRA_TABLE_HTML, getTableHtml());
+            startActivity(intent);
+        }
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
-
         HtmlTextView text = (HtmlTextView) findViewById(R.id.html_text);
-
-        text.setHtmlFromString("<h2>Hello world</h2><ul><li>cats</li><li>dogs Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet</li></ul><br/><ol><li>first</li><li>second<ol><li>second - first<br/>newline</li></ol></li></ol><br/><img src=\"cat\"/><br/><br/>A very long text follows below and it contains bold parts. This can cause a crash <a href=\"http://code.google.com/p/android/issues/detail?id=35466\">on some Android versions</a> when using a normal TextView, but our implementation should workaround that bug.<br/><br/>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>", new HtmlTextView.LocalImageGetter());
+        text.setClickableTableSpan(new ClickableTableSpanImpl());
+        DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
+        drawTableLinkSpan.setTableLinkText("[tap for table]");
+        text.setDrawTableLinkSpan(drawTableLinkSpan);
+        text.setHtmlFromString(
+                "<h2>Hello world</h2>" +
+                        "<table>" +
+                        "   <tr>" +
+                        "       <th>Header 1</th>" +
+                        "       <th>Header 2</th>" +
+                        "   </tr>" +
+                        "   <tr>" +
+                        "       <td>mo data</td>" +
+                        "       <td>mo problems</td>" +
+                        "   </tr>" +
+                        "</table>" +
+                        "<br/>" +
+                        "<ul>" +
+                        "   <li>cats</li>" +
+                        "   <li>dogs Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem" +
+                        "   ipsum dolor sit amet</li>" +
+                        "</ul>" +
+                        "<br/>" +
+                        "<ol>" +
+                        "   <li>first</li>" +
+                        "   <li>second" +
+                        "       <ol>" +
+                        "           <li>second - first" +
+                        "           <br/>newline" +
+                        "           </li>" +
+                        "       </ol>" +
+                        "   </li>" +
+                        "</ol>" +
+                        "<table>" +
+                        "   <tr>" +
+                        "       <th>Month</th>" +
+                        "       <th>Savings</th>" +
+                        "   </tr>" +
+                        "   <tr>" +
+                        "       <td>January</td>" +
+                        "       <td>$100</td>" +
+                        "   </tr>" +
+                        "   <tr>" +
+                        "       <td>" +
+                        "               <TABLE>" +
+                        "           <TR>" +
+                        "                       <TH>Header 1</TH>" +
+                        "                       <TH>Header 2</TH>" +
+                        "           </TR>" +
+                        "           <TR>" +
+                        "           <TD>1st cell</TD>" +
+                        "           <TD>2nd cell</TD>" +
+                        "           </TR>" +
+                        "           </TABLE>" +
+                        "       </td>" +
+                        "       <td>yo dawg</td>" +
+                        "   </tr>" +
+                        "</table>" +
+                        "<br/>" +
+                        "<img src=\"cat\"/>" +
+                        "<br/>A very long text follows below and it contains bold parts. This can" +
+                        "cause a crash " +
+                        "<a href=\"http://code.google.com/p/android/issues/detail?id=35466\">on some" +
+                        " Android versions</a> when using a normal TextView, but our implementation " +
+                        "should workaround that bug." +
+                        "<br/>" +
+                        "<br/>" +
+                        "Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>",
+                new HtmlTextView.LocalImageGetter());
     }
-
 }

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/WebViewActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/WebViewActivity.java
@@ -1,0 +1,21 @@
+package org.sufficientlysecure.htmltextview.example;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.webkit.WebView;
+
+public class WebViewActivity extends AppCompatActivity {
+    public static final String EXTRA_TABLE_HTML = "EXTRA_TABLE_HTML";
+
+    private WebView mWebView;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.activity_web_view);
+        String tableHtml = getIntent().getStringExtra(EXTRA_TABLE_HTML);
+        mWebView = (WebView) findViewById(R.id.web_view);
+        mWebView.loadData(tableHtml, "text/html", "UTF-8");
+    }
+}

--- a/example/src/main/res/layout/activity_web_view.xml
+++ b/example/src/main/res/layout/activity_web_view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/web_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>


### PR DESCRIPTION
This PR adds an imperfect workaround for adding table support by adding two spans: ClickableTableSpan and DrawTableLinkSpan.

These spans provide limited table support by reconstructing the HTML and passing it to an app-defined implementation of ClickTableSpan (which could possibly forward it to a WebView similar to what's shown in the example).

The DrawTableSpan does not need to be implemented, but we expose it so that applications can display text other than "[tap for table]", which is useful for localization.

This PR is imperfect because once we start keeping track of a table tag, we are only able to keep track of other tags which android doesn't handle by default, so the raw html passed to the ClickableTableSpan won't necessarily be correct.