### PR TITLE
Add setRemoveFromHtmlSpace function/ cleanup example

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -126,11 +126,11 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
         htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
         htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
-        if (removeFromHtmlSpace)
+        if (removeFromHtmlSpace) {
             setText(removeHtmlBottomPadding(Html.fromHtml(html, htmlImageGetter, htmlTagHandler)));
-        else
+        } else {
             setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
-
+        }
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());
     }
@@ -166,10 +166,11 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
     }
 
     private CharSequence removeHtmlBottomPadding(CharSequence text) {
-        if (text == null)
+        if (text == null) {
             return null;
-        if (text.length() == 0)
+        } else if (text.length() == 0) {
             return text;
+        }
 
         while (text.charAt(text.length() - 1) == '\n') {
             text = text.subSequence(0, text.length() - 1);

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -27,130 +27,153 @@ import java.util.Scanner;
 
 public class HtmlTextView extends JellyBeanSpanFixTextView {
 
-    public static final String TAG = "HtmlTextView";
-    public static final boolean DEBUG = false;
-    boolean mDontConsumeNonUrlClicks = true;
-    boolean mLinkHit;
-    private ClickableTableSpan mClickableTableSpan;
-    private DrawTableLinkSpan mDrawTableLinkSpan;
+  public static final String TAG = "HtmlTextView";
+  public static final boolean DEBUG = false;
+  boolean mDontConsumeNonUrlClicks = true;
+  boolean mLinkHit;
+  private boolean removeFromHtmlSpace = false;
+  private ClickableTableSpan mClickableTableSpan;
+  private DrawTableLinkSpan mDrawTableLinkSpan;
 
-    public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
-        super(context, attrs, defStyle);
+  public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
+    super(context, attrs, defStyle);
+  }
+
+  public HtmlTextView(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public HtmlTextView(Context context) {
+    super(context);
+  }
+
+  /**
+   * Note that this must be called before setting text for it to work
+   */
+  public void setRemoveFromHtmlSpace(boolean removeFromHtmlSpace) {
+    this.removeFromHtmlSpace = removeFromHtmlSpace;
+  }
+
+  public interface ImageGetter {
+  }
+
+  public static class LocalImageGetter implements ImageGetter {
+  }
+
+  public static class RemoteImageGetter implements ImageGetter {
+    public String baseUrl;
+
+    public RemoteImageGetter() {
     }
 
-    public HtmlTextView(Context context, AttributeSet attrs) {
-        super(context, attrs);
+    public RemoteImageGetter(String baseUrl) {
+      this.baseUrl = baseUrl;
+    }
+  }
+
+  /**
+   * http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
+   */
+  static private String convertStreamToString(InputStream is) {
+    Scanner s = new Scanner(is).useDelimiter("\\A");
+    return s.hasNext() ? s.next() : "";
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent event) {
+    mLinkHit = false;
+    boolean res = super.onTouchEvent(event);
+
+    if (mDontConsumeNonUrlClicks) {
+      return mLinkHit;
+    }
+    return res;
+  }
+
+  /**
+   * Loads HTML from a raw resource, i.e., a HTML file in res/raw/.
+   * This allows translatable resource (e.g., res/raw-de/ for german).
+   * The containing HTML is parsed to Android's Spannable format and then displayed.
+   *
+   * @param context Context
+   * @param resId   for example: R.raw.help
+   */
+  public void setHtmlFromRawResource(Context context, int resId, ImageGetter imageGetter) {
+    // load html from html file from /res/raw
+    InputStream inputStreamText = context.getResources().openRawResource(resId);
+
+    setHtmlFromString(convertStreamToString(inputStreamText), imageGetter);
+  }
+
+  /**
+   * Parses String containing HTML to Android's Spannable format and displays it in this TextView.
+   *
+   * @param html String containing HTML, for example: "<b>Hello world!</b>"
+   */
+  public void setHtmlFromString(String html, ImageGetter imageGetter) {
+    Html.ImageGetter htmlImageGetter;
+    if (imageGetter instanceof LocalImageGetter) {
+      htmlImageGetter = new HtmlLocalImageGetter(getContext());
+    } else if (imageGetter instanceof RemoteImageGetter) {
+      htmlImageGetter = new HtmlRemoteImageGetter(this,
+          ((RemoteImageGetter) imageGetter).baseUrl);
+    } else {
+      Log.e(TAG, "Wrong imageGetter!");
+      return;
     }
 
-    public HtmlTextView(Context context) {
-        super(context);
+    // this uses Android's Html class for basic parsing, and HtmlTagHandler
+    final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
+    htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
+    htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
+    if (removeFromHtmlSpace)
+      setText(removeHtmlBottomPadding(Html.fromHtml(html, htmlImageGetter, htmlTagHandler)));
+    else
+      setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
+
+    // make links work
+    setMovementMethod(LocalLinkMovementMethod.getInstance());
+  }
+
+  /**
+   * @deprecated
+   */
+  public void setHtmlFromRawResource(Context context, int resId, boolean useLocalDrawables) {
+    if (useLocalDrawables) {
+      setHtmlFromRawResource(context, resId, new LocalImageGetter());
+    } else {
+      setHtmlFromRawResource(context, resId, new RemoteImageGetter());
     }
+  }
 
-    public interface ImageGetter {
+  /**
+   * @deprecated
+   */
+  public void setHtmlFromString(String html, boolean useLocalDrawables) {
+    if (useLocalDrawables) {
+      setHtmlFromString(html, new LocalImageGetter());
+    } else {
+      setHtmlFromString(html, new RemoteImageGetter());
     }
+  }
 
-    public static class LocalImageGetter implements ImageGetter {
+  public void setClickableTableSpan(ClickableTableSpan clickableTableSpan) {
+    this.mClickableTableSpan = clickableTableSpan;
+  }
+
+  public void setDrawTableLinkSpan(DrawTableLinkSpan drawTableLinkSpan) {
+    this.mDrawTableLinkSpan = drawTableLinkSpan;
+  }
+
+  private CharSequence removeHtmlBottomPadding(CharSequence text) {
+    if (text == null)
+      return null;
+    if (text.length() == 0)
+      return text;
+
+    while (text.charAt(text.length() - 1) == '\n') {
+      text = text.subSequence(0, text.length() - 1);
     }
-
-    public static class RemoteImageGetter implements ImageGetter {
-        public String baseUrl;
-
-        public RemoteImageGetter() {
-        }
-
-        public RemoteImageGetter(String baseUrl) {
-            this.baseUrl = baseUrl;
-        }
-    }
-
-    /**
-     * http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
-     */
-    static private String convertStreamToString(InputStream is) {
-        Scanner s = new Scanner(is).useDelimiter("\\A");
-        return s.hasNext() ? s.next() : "";
-    }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        mLinkHit = false;
-        boolean res = super.onTouchEvent(event);
-
-        if (mDontConsumeNonUrlClicks) {
-            return mLinkHit;
-        }
-        return res;
-    }
-
-    /**
-     * Loads HTML from a raw resource, i.e., a HTML file in res/raw/.
-     * This allows translatable resource (e.g., res/raw-de/ for german).
-     * The containing HTML is parsed to Android's Spannable format and then displayed.
-     *
-     * @param context Context
-     * @param resId   for example: R.raw.help
-     */
-    public void setHtmlFromRawResource(Context context, int resId, ImageGetter imageGetter) {
-        // load html from html file from /res/raw
-        InputStream inputStreamText = context.getResources().openRawResource(resId);
-
-        setHtmlFromString(convertStreamToString(inputStreamText), imageGetter);
-    }
-
-    /**
-     * Parses String containing HTML to Android's Spannable format and displays it in this TextView.
-     *
-     * @param html String containing HTML, for example: "<b>Hello world!</b>"
-     */
-    public void setHtmlFromString(String html, ImageGetter imageGetter) {
-        Html.ImageGetter htmlImageGetter;
-        if (imageGetter instanceof LocalImageGetter) {
-            htmlImageGetter = new HtmlLocalImageGetter(getContext());
-        } else if (imageGetter instanceof RemoteImageGetter) {
-            htmlImageGetter = new HtmlRemoteImageGetter(this,
-                    ((RemoteImageGetter) imageGetter).baseUrl);
-        } else {
-            Log.e(TAG, "Wrong imageGetter!");
-            return;
-        }
-
-        // this uses Android's Html class for basic parsing, and HtmlTagHandler
-        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
-        htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
-        htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
-        setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
-
-        // make links work
-        setMovementMethod(LocalLinkMovementMethod.getInstance());
-    }
-
-    /**
-     * @deprecated
-     */
-    public void setHtmlFromRawResource(Context context, int resId, boolean useLocalDrawables) {
-        if (useLocalDrawables) {
-            setHtmlFromRawResource(context, resId, new LocalImageGetter());
-        } else {
-            setHtmlFromRawResource(context, resId, new RemoteImageGetter());
-        }
-    }
-
-    /**
-     * @deprecated
-     */
-    public void setHtmlFromString(String html, boolean useLocalDrawables) {
-        if (useLocalDrawables) {
-            setHtmlFromString(html, new LocalImageGetter());
-        } else {
-            setHtmlFromString(html, new RemoteImageGetter());
-        }
-    }
-
-    public void setClickableTableSpan(ClickableTableSpan clickableTableSpan) {
-        this.mClickableTableSpan = clickableTableSpan;
-    }
-
-    public void setDrawTableLinkSpan(DrawTableLinkSpan drawTableLinkSpan) {
-        this.mDrawTableLinkSpan = drawTableLinkSpan;
-    }
+    return text;
+  }
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -27,153 +27,153 @@ import java.util.Scanner;
 
 public class HtmlTextView extends JellyBeanSpanFixTextView {
 
-  public static final String TAG = "HtmlTextView";
-  public static final boolean DEBUG = false;
-  boolean mDontConsumeNonUrlClicks = true;
-  boolean mLinkHit;
-  private boolean removeFromHtmlSpace = false;
-  private ClickableTableSpan mClickableTableSpan;
-  private DrawTableLinkSpan mDrawTableLinkSpan;
+    public static final String TAG = "HtmlTextView";
+    public static final boolean DEBUG = false;
+    boolean mDontConsumeNonUrlClicks = true;
+    boolean mLinkHit;
+    private boolean removeFromHtmlSpace = false;
+    private ClickableTableSpan mClickableTableSpan;
+    private DrawTableLinkSpan mDrawTableLinkSpan;
 
-  public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
-    super(context, attrs, defStyle);
-  }
-
-  public HtmlTextView(Context context, AttributeSet attrs) {
-    super(context, attrs);
-  }
-
-  public HtmlTextView(Context context) {
-    super(context);
-  }
-
-  /**
-   * Note that this must be called before setting text for it to work
-   */
-  public void setRemoveFromHtmlSpace(boolean removeFromHtmlSpace) {
-    this.removeFromHtmlSpace = removeFromHtmlSpace;
-  }
-
-  public interface ImageGetter {
-  }
-
-  public static class LocalImageGetter implements ImageGetter {
-  }
-
-  public static class RemoteImageGetter implements ImageGetter {
-    public String baseUrl;
-
-    public RemoteImageGetter() {
+    public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
     }
 
-    public RemoteImageGetter(String baseUrl) {
-      this.baseUrl = baseUrl;
-    }
-  }
-
-  /**
-   * http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
-   */
-  static private String convertStreamToString(InputStream is) {
-    Scanner s = new Scanner(is).useDelimiter("\\A");
-    return s.hasNext() ? s.next() : "";
-  }
-
-  @Override
-  public boolean onTouchEvent(MotionEvent event) {
-    mLinkHit = false;
-    boolean res = super.onTouchEvent(event);
-
-    if (mDontConsumeNonUrlClicks) {
-      return mLinkHit;
-    }
-    return res;
-  }
-
-  /**
-   * Loads HTML from a raw resource, i.e., a HTML file in res/raw/.
-   * This allows translatable resource (e.g., res/raw-de/ for german).
-   * The containing HTML is parsed to Android's Spannable format and then displayed.
-   *
-   * @param context Context
-   * @param resId   for example: R.raw.help
-   */
-  public void setHtmlFromRawResource(Context context, int resId, ImageGetter imageGetter) {
-    // load html from html file from /res/raw
-    InputStream inputStreamText = context.getResources().openRawResource(resId);
-
-    setHtmlFromString(convertStreamToString(inputStreamText), imageGetter);
-  }
-
-  /**
-   * Parses String containing HTML to Android's Spannable format and displays it in this TextView.
-   *
-   * @param html String containing HTML, for example: "<b>Hello world!</b>"
-   */
-  public void setHtmlFromString(String html, ImageGetter imageGetter) {
-    Html.ImageGetter htmlImageGetter;
-    if (imageGetter instanceof LocalImageGetter) {
-      htmlImageGetter = new HtmlLocalImageGetter(getContext());
-    } else if (imageGetter instanceof RemoteImageGetter) {
-      htmlImageGetter = new HtmlRemoteImageGetter(this,
-          ((RemoteImageGetter) imageGetter).baseUrl);
-    } else {
-      Log.e(TAG, "Wrong imageGetter!");
-      return;
+    public HtmlTextView(Context context, AttributeSet attrs) {
+        super(context, attrs);
     }
 
-    // this uses Android's Html class for basic parsing, and HtmlTagHandler
-    final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
-    htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
-    htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
-    if (removeFromHtmlSpace)
-      setText(removeHtmlBottomPadding(Html.fromHtml(html, htmlImageGetter, htmlTagHandler)));
-    else
-      setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
-
-    // make links work
-    setMovementMethod(LocalLinkMovementMethod.getInstance());
-  }
-
-  /**
-   * @deprecated
-   */
-  public void setHtmlFromRawResource(Context context, int resId, boolean useLocalDrawables) {
-    if (useLocalDrawables) {
-      setHtmlFromRawResource(context, resId, new LocalImageGetter());
-    } else {
-      setHtmlFromRawResource(context, resId, new RemoteImageGetter());
+    public HtmlTextView(Context context) {
+        super(context);
     }
-  }
 
-  /**
-   * @deprecated
-   */
-  public void setHtmlFromString(String html, boolean useLocalDrawables) {
-    if (useLocalDrawables) {
-      setHtmlFromString(html, new LocalImageGetter());
-    } else {
-      setHtmlFromString(html, new RemoteImageGetter());
+    /**
+     * Note that this must be called before setting text for it to work
+     */
+    public void setRemoveFromHtmlSpace(boolean removeFromHtmlSpace) {
+        this.removeFromHtmlSpace = removeFromHtmlSpace;
     }
-  }
 
-  public void setClickableTableSpan(ClickableTableSpan clickableTableSpan) {
-    this.mClickableTableSpan = clickableTableSpan;
-  }
-
-  public void setDrawTableLinkSpan(DrawTableLinkSpan drawTableLinkSpan) {
-    this.mDrawTableLinkSpan = drawTableLinkSpan;
-  }
-
-  private CharSequence removeHtmlBottomPadding(CharSequence text) {
-    if (text == null)
-      return null;
-    if (text.length() == 0)
-      return text;
-
-    while (text.charAt(text.length() - 1) == '\n') {
-      text = text.subSequence(0, text.length() - 1);
+    public interface ImageGetter {
     }
-    return text;
-  }
+
+    public static class LocalImageGetter implements ImageGetter {
+    }
+
+    public static class RemoteImageGetter implements ImageGetter {
+        public String baseUrl;
+
+        public RemoteImageGetter() {
+        }
+
+        public RemoteImageGetter(String baseUrl) {
+            this.baseUrl = baseUrl;
+        }
+    }
+
+    /**
+     * http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
+     */
+    static private String convertStreamToString(InputStream is) {
+        Scanner s = new Scanner(is).useDelimiter("\\A");
+        return s.hasNext() ? s.next() : "";
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        mLinkHit = false;
+        boolean res = super.onTouchEvent(event);
+
+        if (mDontConsumeNonUrlClicks) {
+            return mLinkHit;
+        }
+        return res;
+    }
+
+    /**
+     * Loads HTML from a raw resource, i.e., a HTML file in res/raw/.
+     * This allows translatable resource (e.g., res/raw-de/ for german).
+     * The containing HTML is parsed to Android's Spannable format and then displayed.
+     *
+     * @param context Context
+     * @param resId   for example: R.raw.help
+     */
+    public void setHtmlFromRawResource(Context context, int resId, ImageGetter imageGetter) {
+        // load html from html file from /res/raw
+        InputStream inputStreamText = context.getResources().openRawResource(resId);
+
+        setHtmlFromString(convertStreamToString(inputStreamText), imageGetter);
+    }
+
+    /**
+     * Parses String containing HTML to Android's Spannable format and displays it in this TextView.
+     *
+     * @param html String containing HTML, for example: "<b>Hello world!</b>"
+     */
+    public void setHtmlFromString(String html, ImageGetter imageGetter) {
+        Html.ImageGetter htmlImageGetter;
+        if (imageGetter instanceof LocalImageGetter) {
+            htmlImageGetter = new HtmlLocalImageGetter(getContext());
+        } else if (imageGetter instanceof RemoteImageGetter) {
+            htmlImageGetter = new HtmlRemoteImageGetter(this,
+                    ((RemoteImageGetter) imageGetter).baseUrl);
+        } else {
+            Log.e(TAG, "Wrong imageGetter!");
+            return;
+        }
+
+        // this uses Android's Html class for basic parsing, and HtmlTagHandler
+        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
+        htmlTagHandler.setClickableTableSpan(mClickableTableSpan);
+        htmlTagHandler.setDrawTableLinkSpan(mDrawTableLinkSpan);
+        if (removeFromHtmlSpace)
+            setText(removeHtmlBottomPadding(Html.fromHtml(html, htmlImageGetter, htmlTagHandler)));
+        else
+            setText(Html.fromHtml(html, htmlImageGetter, htmlTagHandler));
+
+        // make links work
+        setMovementMethod(LocalLinkMovementMethod.getInstance());
+    }
+
+    /**
+     * @deprecated
+     */
+    public void setHtmlFromRawResource(Context context, int resId, boolean useLocalDrawables) {
+        if (useLocalDrawables) {
+            setHtmlFromRawResource(context, resId, new LocalImageGetter());
+        } else {
+            setHtmlFromRawResource(context, resId, new RemoteImageGetter());
+        }
+    }
+
+    /**
+     * @deprecated
+     */
+    public void setHtmlFromString(String html, boolean useLocalDrawables) {
+        if (useLocalDrawables) {
+            setHtmlFromString(html, new LocalImageGetter());
+        } else {
+            setHtmlFromString(html, new RemoteImageGetter());
+        }
+    }
+
+    public void setClickableTableSpan(ClickableTableSpan clickableTableSpan) {
+        this.mClickableTableSpan = clickableTableSpan;
+    }
+
+    public void setDrawTableLinkSpan(DrawTableLinkSpan drawTableLinkSpan) {
+        this.mDrawTableLinkSpan = drawTableLinkSpan;
+    }
+
+    private CharSequence removeHtmlBottomPadding(CharSequence text) {
+        if (text == null)
+            return null;
+        if (text.length() == 0)
+            return text;
+
+        while (text.charAt(text.length() - 1) == '\n') {
+            text = text.subSequence(0, text.length() - 1);
+        }
+        return text;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ See LICENSE for full license text.
 - Original [HtmlLocalImageGetter](http://stackoverflow.com/a/22298833) developed by drawk
 - [JellyBeanSpanFixTextView](https://gist.github.com/pyricau/3424004) (with fix from comment) developed by Pierre-Yves Ricau
 - [Table support](https://github.com/SufficientlySecure/html-textview/pull/33) added by Richard Thai
+- [setRemoveFromHtmlSpace](https://github.com/SufficientlySecure/html-textview/pull/37) added by [Derek Smith](https://github.com/derekcsm)
 
 ## Contributions
 

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -17,36 +17,36 @@ import static org.sufficientlysecure.htmltextview.example.WebViewActivity.EXTRA_
 
 public class MainActivity extends Activity {
 
-  // The html table(s) are individually passed through to the ClickableTableSpan implementation
-  // presumably for a WebView activity.
-  class ClickableTableSpanImpl extends ClickableTableSpan {
-    @Override
-    public ClickableTableSpan newInstance() {
-      return new ClickableTableSpanImpl();
+    // The html table(s) are individually passed through to the ClickableTableSpan implementation
+    // presumably for a WebView activity.
+    class ClickableTableSpanImpl extends ClickableTableSpan {
+        @Override
+        public ClickableTableSpan newInstance() {
+            return new ClickableTableSpanImpl();
+        }
+
+        @Override
+        public void onClick(View widget) {
+            Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
+            intent.putExtra(EXTRA_TABLE_HTML, getTableHtml());
+            startActivity(intent);
+        }
     }
 
     @Override
-    public void onClick(View widget) {
-      Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
-      intent.putExtra(EXTRA_TABLE_HTML, getTableHtml());
-      startActivity(intent);
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        HtmlTextView text = (HtmlTextView) findViewById(R.id.html_text);
+
+        text.setRemoveFromHtmlSpace(true);
+        text.setClickableTableSpan(new ClickableTableSpanImpl());
+        DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
+        drawTableLinkSpan.setTableLinkText("[tap for table]");
+        text.setDrawTableLinkSpan(drawTableLinkSpan);
+        text.setHtmlFromString(getResources().getString(R.string.test_html),
+                new HtmlTextView.LocalImageGetter());
     }
-  }
-
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.activity_main);
-
-    HtmlTextView text = (HtmlTextView) findViewById(R.id.html_text);
-
-    text.setRemoveFromHtmlSpace(true);
-    text.setClickableTableSpan(new ClickableTableSpanImpl());
-    DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
-    drawTableLinkSpan.setTableLinkText("[tap for table]");
-    text.setDrawTableLinkSpan(drawTableLinkSpan);
-    text.setHtmlFromString(getResources().getString(R.string.test_html),
-        new HtmlTextView.LocalImageGetter());
-  }
 
 }

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -1,8 +1,12 @@
 package org.sufficientlysecure.htmltextview.example;
 
 import android.app.Activity;
+import android.content.Context;
 import android.content.Intent;
+import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.support.v4.content.ContextCompat;
+import android.text.Html;
 import android.view.View;
 
 import org.sufficientlysecure.htmltextview.ClickableTableSpan;
@@ -13,95 +17,36 @@ import static org.sufficientlysecure.htmltextview.example.WebViewActivity.EXTRA_
 
 public class MainActivity extends Activity {
 
-    // The html table(s) are individually passed through to the ClickableTableSpan implementation
-    // presumably for a WebView activity.
-    class ClickableTableSpanImpl extends ClickableTableSpan {
-        @Override
-        public ClickableTableSpan newInstance() {
-            return new ClickableTableSpanImpl();
-        }
-
-        @Override
-        public void onClick(View widget) {
-            Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
-            intent.putExtra(EXTRA_TABLE_HTML, getTableHtml());
-            startActivity(intent);
-        }
+  // The html table(s) are individually passed through to the ClickableTableSpan implementation
+  // presumably for a WebView activity.
+  class ClickableTableSpanImpl extends ClickableTableSpan {
+    @Override
+    public ClickableTableSpan newInstance() {
+      return new ClickableTableSpanImpl();
     }
 
     @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_main);
-        HtmlTextView text = (HtmlTextView) findViewById(R.id.html_text);
-        text.setClickableTableSpan(new ClickableTableSpanImpl());
-        DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
-        drawTableLinkSpan.setTableLinkText("[tap for table]");
-        text.setDrawTableLinkSpan(drawTableLinkSpan);
-        text.setHtmlFromString(
-                "<h2>Hello world</h2>" +
-                        "<table>" +
-                        "   <tr>" +
-                        "       <th>Header 1</th>" +
-                        "       <th>Header 2</th>" +
-                        "   </tr>" +
-                        "   <tr>" +
-                        "       <td>mo data</td>" +
-                        "       <td>mo problems</td>" +
-                        "   </tr>" +
-                        "</table>" +
-                        "<br/>" +
-                        "<ul>" +
-                        "   <li>cats</li>" +
-                        "   <li>dogs Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem" +
-                        "   ipsum dolor sit amet</li>" +
-                        "</ul>" +
-                        "<br/>" +
-                        "<ol>" +
-                        "   <li>first</li>" +
-                        "   <li>second" +
-                        "       <ol>" +
-                        "           <li>second - first" +
-                        "           <br/>newline" +
-                        "           </li>" +
-                        "       </ol>" +
-                        "   </li>" +
-                        "</ol>" +
-                        "<table>" +
-                        "   <tr>" +
-                        "       <th>Month</th>" +
-                        "       <th>Savings</th>" +
-                        "   </tr>" +
-                        "   <tr>" +
-                        "       <td>January</td>" +
-                        "       <td>$100</td>" +
-                        "   </tr>" +
-                        "   <tr>" +
-                        "       <td>" +
-                        "               <TABLE>" +
-                        "           <TR>" +
-                        "                       <TH>Header 1</TH>" +
-                        "                       <TH>Header 2</TH>" +
-                        "           </TR>" +
-                        "           <TR>" +
-                        "           <TD>1st cell</TD>" +
-                        "           <TD>2nd cell</TD>" +
-                        "           </TR>" +
-                        "           </TABLE>" +
-                        "       </td>" +
-                        "       <td>yo dawg</td>" +
-                        "   </tr>" +
-                        "</table>" +
-                        "<br/>" +
-                        "<img src=\"cat\"/>" +
-                        "<br/>A very long text follows below and it contains bold parts. This can" +
-                        "cause a crash " +
-                        "<a href=\"http://code.google.com/p/android/issues/detail?id=35466\">on some" +
-                        " Android versions</a> when using a normal TextView, but our implementation " +
-                        "should workaround that bug." +
-                        "<br/>" +
-                        "<br/>" +
-                        "Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>Lo<b>remips</b>umdol<b>orsita</b>metLorem<b>ipsu</b>mdo<b>lorsit</b>ametLoremip<b>sumdolorsitamet.</b>",
-                new HtmlTextView.LocalImageGetter());
+    public void onClick(View widget) {
+      Intent intent = new Intent(MainActivity.this, WebViewActivity.class);
+      intent.putExtra(EXTRA_TABLE_HTML, getTableHtml());
+      startActivity(intent);
     }
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.activity_main);
+
+    HtmlTextView text = (HtmlTextView) findViewById(R.id.html_text);
+
+    text.setRemoveFromHtmlSpace(true);
+    text.setClickableTableSpan(new ClickableTableSpanImpl());
+    DrawTableLinkSpan drawTableLinkSpan = new DrawTableLinkSpan();
+    drawTableLinkSpan.setTableLinkText("[tap for table]");
+    text.setDrawTableLinkSpan(drawTableLinkSpan);
+    text.setHtmlFromString(getResources().getString(R.string.test_html),
+        new HtmlTextView.LocalImageGetter());
+  }
+
 }

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -5,28 +5,28 @@
             android:background="#f8f8f8"
             tools:context=".MainActivity">
 
-  <LinearLayout
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/activity_vertical_margin"/>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/activity_vertical_margin"/>
 
-    <org.sufficientlysecure.htmltextview.HtmlTextView
-      android:id="@+id/html_text"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:background="@android:color/white"
-      android:layout_marginLeft="@dimen/activity_horizontal_margin"
-      android:layout_marginRight="@dimen/activity_horizontal_margin"
-      android:textAppearance="@android:style/TextAppearance.Small"/>
+        <org.sufficientlysecure.htmltextview.HtmlTextView
+            android:id="@+id/html_text"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="@dimen/activity_horizontal_margin"
+            android:layout_marginRight="@dimen/activity_horizontal_margin"
+            android:background="@android:color/white"
+            android:textAppearance="@android:style/TextAppearance.Small"/>
 
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="@dimen/activity_vertical_margin"/>
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/activity_vertical_margin"/>
 
-  </LinearLayout>
+    </LinearLayout>
 
 </ScrollView>

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -1,17 +1,32 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+            xmlns:tools="http://schemas.android.com/tools"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="#f8f8f8"
+            tools:context=".MainActivity">
+
+  <LinearLayout
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/activity_vertical_margin"/>
 
     <org.sufficientlysecure.htmltextview.HtmlTextView
-        android:id="@+id/html_text"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingTop="@dimen/activity_vertical_margin"
-        android:paddingBottom="@dimen/activity_vertical_margin"
-        android:textAppearance="@android:style/TextAppearance.Small" />
+      android:id="@+id/html_text"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:background="@android:color/white"
+      android:layout_marginLeft="@dimen/activity_horizontal_margin"
+      android:layout_marginRight="@dimen/activity_horizontal_margin"
+      android:textAppearance="@android:style/TextAppearance.Small"/>
+
+    <View
+      android:layout_width="match_parent"
+      android:layout_height="@dimen/activity_vertical_margin"/>
+
+  </LinearLayout>
 
 </ScrollView>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">HtmlTextView Example</string>
+    <string name="app_name">HtmlTextView Example</string>
 
     <string name="test_html"><![CDATA[
     <p>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -1,3 +1,99 @@
 <resources>
-    <string name="app_name">HtmlTextView Example</string>
+  <string name="app_name">HtmlTextView Example</string>
+
+    <string name="test_html"><![CDATA[
+    <p>
+    <h2>Hello world</h2>
+    <table>
+      <tr>
+        <th>Header 1</th>
+        <th>Header 2</th>
+      </tr>
+      <tr>
+        <td>mo data</td>
+        <td>mo problems</td>
+       </tr>
+    </table>
+    <br/>
+      <ul>
+        <li>cats</li>
+        <li>dogs Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet Lorem ipsum dolor sit amet</li>
+      </ul>
+    <br/>
+    <ol>
+      <li>first</li>
+      <li>second
+        <ol>
+          <li>second - first
+          <br/>
+          newline
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <table>
+      <tr>
+        <th>Month</th>
+        <th>Savings</th>
+      </tr>
+      <tr>
+        <td>January</td>
+        <td>$1,000,000</td>
+      </tr>
+      <tr>
+        <td>
+          <TABLE>
+            <TR>
+              <TH>Header 1</TH>
+              <TH>Header 2</TH>
+            </TR>
+            <TR>
+               <TH>Cell 1</TH>
+              <TH>Cell 2</TH>
+            </TR>
+          </TABLE>
+        </td>
+        <td>yo dawg</td>
+      </tr>
+    </table>
+    <br/>
+    <img src=\"cat\"/>
+    <br/>
+    A very long text follows below and it contains bold parts. This can cause a crash
+    <a href="http://code.google.com/p/android/issues/detail?id=35466">on some Android versions</a>
+    when using a normal TextView, but our implementation should workaround that bug.
+    <br/>
+    <br/>
+    <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut eros sed arcu auctor tincidunt
+    id sit amet elit. Mauris in faucibus neque. Suspendisse facilisis urna nec nisi convallis tincidunt.
+    Mauris at elit et arcu viverra auctor. Nullam et arcu ultricies, iaculis dolor efficitur, tristique eros.
+    Interdum et malesuada <b>some bold text in here</b> fames ac ante ipsum primis in faucibus.
+    Integer nec aliquet mi. Aenean ipsum odio,
+    iaculis et est eget, condimentum bibendum dui. Aenean nec elementum tortor. Vestibulum tincidunt mi sit
+    amet tortor semper tincidunt. Sed tincidunt metus et pretium semper. Phasellus neque est, congue nec
+    metus ac, ullamcorper varius sapien. Integer nec tortor vel justo finibus gravida id quis purus.
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vestibulum
+    aliquam convallis dapibus. Aenean suscipit, orci id elementum vehicula, odio arcu fringilla massa,
+    vel imperdiet augue est non mi.
+    </p>
+    <p>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut eros sed arcu auctor tincidunt
+    id sit amet elit. Mauris in faucibus neque. Suspendisse facilisis urna nec nisi convallis tincidunt.
+    Mauris at elit et arcu viverra auctor. Nullam et arcu ultricies, iaculis dolor efficitur, tristique eros.
+    Interdum et malesuada fames ac ante ipsum primis in faucibus. Integer nec aliquet mi. Aenean ipsum odio,
+    iaculis et est eget, condimentum bibendum dui. Aenean nec elementum tortor. Vestibulum tincidunt mi sit
+    amet tortor semper tincidunt. Sed tincidunt metus et pretium semper. Phasellus neque est, congue nec
+    metus ac, <b>ullamcorper varius sapien. Integer nec tortor vel justo finibus gravida id quis purus.</b>
+    Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vestibulum
+    aliquam convallis dapibus. Aenean suscipit, orci id elementum vehicula, odio arcu fringilla massa,
+    vel imperdiet augue est non mi.
+    </p>
+    <p>
+    Android will add extra space at the bottom of the textView by default fromHtml,
+    use <code>setRemoveFromHtmlSpace(false)</code> on your <b>HtmlTextView</b>
+    before setting text to prevent this from happening.
+    </p
+    </p>
+    ]]></string>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -91,7 +91,7 @@
     </p>
     <p>
     Android will add extra space at the bottom of the textView by default fromHtml,
-    use <code>setRemoveFromHtmlSpace(false)</code> on your <b>HtmlTextView</b>
+    use <code>setRemoveFromHtmlSpace(true)</code> on your <b>HtmlTextView</b>
     before setting text to prevent this from happening.
     </p
     </p>


### PR DESCRIPTION
This commit adds the option of having HtmlTextView automatically trim the extra "space" that `Html.fromHtml` sometimes adds to the bottom of text, via a simple `setRemoveFromHtmlSpace(boolean)` method.

`setRemoveFromHtmlSpace` must be called before setting text for the trailing space to be trimmed off it there are any, it will not work after text is already set since it just simply sets a value that will cause `removeHtmlBottomPadding` to be used in `setHtmlFromString` in the `HtmlTextView` class.

I like this approach more than a constructor because it's explicitly optional, straight forward, and not a breaking change, of-course a constructor could be added, w/ potentialy XML attributes so that it can be used from resources, but for now I don't think it's necessary.

I've also cleaned up `MainActivity` in the example app, moved the example html to a string resource, and added `setRemoveFromHtmlSpace` as an example. The `activity_main` layout now also has a slightly darker background from the `HtmlTextView` so that you can clearly see the bounds w/o using developer options "show layout bounds"