### PR TITLE
Indenting entries of ordered lists the same way as of unordered lists

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -155,7 +155,6 @@ public class HtmlTagHandler implements Html.TagHandler {
                 String parentList = lists.peek();
                 if (parentList.equalsIgnoreCase(ORDERED_LIST)) {
                     start(output, new Ol());
-                    output.append(olNextIndex.peek().toString()).append(". ");
                     olNextIndex.push(olNextIndex.pop() + 1);
                 } else if (parentList.equalsIgnoreCase(UNORDERED_LIST)) {
                     start(output, new Ul());
@@ -222,7 +221,10 @@ public class HtmlTagHandler implements Html.TagHandler {
                         // Same as in ordered lists: counter the effect of nested Spans
                         numberMargin -= (lists.size() - 2) * listItemIndent;
                     }
-                    end(output, Ol.class, false, new LeadingMarginSpan.Standard(numberMargin));
+                    NumberSpan numberSpan = new NumberSpan(olNextIndex.lastElement() - 1);
+                    end(output, Ol.class, false,
+                            new LeadingMarginSpan.Standard(numberMargin),
+                            numberSpan);
                 }
             } else if (tag.equalsIgnoreCase("code")) {
                 end(output, Code.class, false, new TypefaceSpan("monospace"));

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2017 Dominik Mosberger <https://github.com/mosberger>
+ * Copyright (C) 2013 Leszek Mzyk <https://github.com/imbryk>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.sufficientlysecure.htmltextview;
 
 import android.graphics.Canvas;
@@ -10,9 +27,6 @@ import android.text.style.LeadingMarginSpan;
  * Class to use Numbered Lists in TextViews.
  * The span works the same as {@link android.text.style.BulletSpan} and all lines of the entry have
  * the same leading margin.
- *
- * Originally written by <a href="https://github.com/imbryk">Leszek Mzyk</a>,
- * modified for {@link org.sufficientlysecure.htmltextview.HtmlTagHandler} by <a href="https://github.com/mosberger">Dominik Mosberger</a>
  */
 public class NumberSpan implements LeadingMarginSpan {
     private final String mNumber;

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
@@ -1,0 +1,42 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.Spanned;
+import android.text.style.LeadingMarginSpan;
+
+/**
+ * Class to use Numbered Lists in TextViews.
+ * The span works the same as {@link android.text.style.BulletSpan} and all lines of the entry have
+ * the same leading margin.
+ *
+ * Originally written by <a href="https://github.com/imbryk">Leszek Mzyk</a>,
+ * modified for {@link org.sufficientlysecure.htmltextview.HtmlTagHandler} by <a href="https://github.com/mosberger">Dominik Mosberger</a>
+ */
+public class NumberSpan implements LeadingMarginSpan {
+    private final String mNumber;
+    private int mTextWidth;
+
+    public NumberSpan(int number) {
+        mNumber = Integer.toString(number).concat(". ");
+    }
+
+    @Override
+    public int getLeadingMargin(boolean first) {
+        return mTextWidth;
+    }
+
+    @Override
+    public void drawLeadingMargin(Canvas c, Paint p, int x, int dir, int top, int baseline,
+                                  int bottom, CharSequence text, int start, int end,
+                                  boolean first, Layout l) {
+        if (text instanceof Spanned) {
+            int spanStart = ((Spanned) text).getSpanStart(this);
+            if (spanStart == start) {
+                mTextWidth = (int) p.measureText(mNumber);
+                c.drawText(mNumber, x, baseline, p);
+            }
+        }
+    }
+}


### PR DESCRIPTION
In the original code, all lines of a multiline entry in an ordered list start at the same indent as the number. The modified code lets the ordered list act like the unordered list with numbering.