### PR TITLE
Fix text cutting bug

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -25,6 +25,7 @@ import android.text.Html;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.style.AlignmentSpan;
 import android.text.style.BulletSpan;
 import android.text.style.LeadingMarginSpan;
@@ -44,6 +45,11 @@ public class HtmlTagHandler implements Html.TagHandler {
     public static final String UNORDERED_LIST = "HTML_TEXTVIEW_ESCAPED_UL_TAG";
     public static final String ORDERED_LIST = "HTML_TEXTVIEW_ESCAPED_OL_TAG";
     public static final String LIST_ITEM = "HTML_TEXTVIEW_ESCAPED_LI_TAG";
+    private final TextPaint mTextPaint;
+
+    public HtmlTagHandler(TextPaint textPaint) {
+        mTextPaint = textPaint;
+    }
 
     /**
      * Newer versions of the Android SDK's {@link Html.TagHandler} handles &lt;ul&gt; and &lt;li&gt;
@@ -221,7 +227,7 @@ public class HtmlTagHandler implements Html.TagHandler {
                         // Same as in ordered lists: counter the effect of nested Spans
                         numberMargin -= (lists.size() - 2) * listItemIndent;
                     }
-                    NumberSpan numberSpan = new NumberSpan(olNextIndex.lastElement() - 1);
+                    NumberSpan numberSpan = new NumberSpan(mTextPaint, olNextIndex.lastElement() - 1);
                     end(output, Ol.class, false,
                             new LeadingMarginSpan.Standard(numberMargin),
                             numberSpan);

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -91,7 +91,7 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      *                    HtmlLocalImageGetter and HtmlRemoteImageGetter
      */
     public void setHtml(@NonNull String html, @Nullable Html.ImageGetter imageGetter) {
-        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
+        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler(getPaint());
         htmlTagHandler.setClickableTableSpan(clickableTableSpan);
         htmlTagHandler.setDrawTableLinkSpan(drawTableLinkSpan);
 

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/NumberSpan.java
@@ -21,6 +21,7 @@ import android.graphics.Canvas;
 import android.graphics.Paint;
 import android.text.Layout;
 import android.text.Spanned;
+import android.text.TextPaint;
 import android.text.style.LeadingMarginSpan;
 
 /**
@@ -30,10 +31,11 @@ import android.text.style.LeadingMarginSpan;
  */
 public class NumberSpan implements LeadingMarginSpan {
     private final String mNumber;
-    private int mTextWidth;
+    private final int mTextWidth;
 
-    public NumberSpan(int number) {
+    public NumberSpan(TextPaint textPaint, int number) {
         mNumber = Integer.toString(number).concat(". ");
+        mTextWidth = (int) textPaint.measureText(mNumber);
     }
 
     @Override
@@ -48,7 +50,6 @@ public class NumberSpan implements LeadingMarginSpan {
         if (text instanceof Spanned) {
             int spanStart = ((Spanned) text).getSpanStart(this);
             if (spanStart == start) {
-                mTextWidth = (int) p.measureText(mNumber);
                 c.drawText(mNumber, x, baseline, p);
             }
         }


### PR DESCRIPTION
The width of the number in NumberSpan is now calculated when it's created. Otherwise the text behind the numbering is cut in the end