### PR TITLE
Fix textIsSelectable on Marshmallow and later

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -22,6 +22,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RawRes;
 import android.text.Html;
 import android.util.AttributeSet;
+import android.view.MotionEvent;
 
 import java.io.InputStream;
 import java.util.Scanner;
@@ -31,11 +32,13 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
     public static final String TAG = "HtmlTextView";
     public static final boolean DEBUG = false;
 
+    boolean linkHit;
     @Nullable
     private ClickableTableSpan clickableTableSpan;
     @Nullable
     private DrawTableLinkSpan drawTableLinkSpan;
 
+    boolean dontConsumeNonUrlClicks = true;
     private boolean removeFromHtmlSpace = true;
 
     public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
@@ -144,4 +147,16 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         }
         return text;
     }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        linkHit = false;
+        boolean res = super.onTouchEvent(event);
+
+        if (dontConsumeNonUrlClicks) {
+            return linkHit;
+        }
+        return res;
+    }
+
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -22,7 +22,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.RawRes;
 import android.text.Html;
 import android.util.AttributeSet;
-import android.view.MotionEvent;
 
 import java.io.InputStream;
 import java.util.Scanner;
@@ -32,13 +31,11 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
     public static final String TAG = "HtmlTextView";
     public static final boolean DEBUG = false;
 
-    boolean linkHit;
     @Nullable
     private ClickableTableSpan clickableTableSpan;
     @Nullable
     private DrawTableLinkSpan drawTableLinkSpan;
 
-    boolean dontConsumeNonUrlClicks = true;
     private boolean removeFromHtmlSpace = true;
 
     public HtmlTextView(Context context, AttributeSet attrs, int defStyle) {
@@ -147,16 +144,4 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         }
         return text;
     }
-
-    @Override
-    public boolean onTouchEvent(MotionEvent event) {
-        linkHit = false;
-        boolean res = super.onTouchEvent(event);
-
-        if (dontConsumeNonUrlClicks) {
-            return linkHit;
-        }
-        return res;
-    }
-
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/LocalLinkMovementMethod.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/LocalLinkMovementMethod.java
@@ -68,6 +68,9 @@ public class LocalLinkMovementMethod extends LinkMovementMethod {
                             buffer.getSpanEnd(link[0]));
                 }
 
+                if (widget instanceof HtmlTextView) {
+                    ((HtmlTextView) widget).linkHit = true;
+                }
                 return true;
             } else {
                 Selection.removeSelection(buffer);

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/LocalLinkMovementMethod.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/LocalLinkMovementMethod.java
@@ -68,9 +68,6 @@ public class LocalLinkMovementMethod extends LinkMovementMethod {
                             buffer.getSpanEnd(link[0]));
                 }
 
-                if (widget instanceof HtmlTextView) {
-                    ((HtmlTextView) widget).linkHit = true;
-                }
                 return true;
             } else {
                 Selection.removeSelection(buffer);

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -21,7 +21,8 @@
             android:layout_marginLeft="@dimen/activity_horizontal_margin"
             android:layout_marginRight="@dimen/activity_horizontal_margin"
             android:background="@android:color/white"
-            android:textAppearance="@android:style/TextAppearance.Small" />
+            android:textAppearance="@android:style/TextAppearance.Small"
+            android:textIsSelectable="true"/>
 
         <View
             android:layout_width="match_parent"


### PR DESCRIPTION
This fixes #59 by removing the unnecessary boolean fields. Previously onTouchEvent() returned false because of these boolean fields, so the text selection bubble didn't appear on Marshmallow and later.

I also enabled `textIsSelectable` in the example app's layout to test the fix.
(There's a revert commit because first I pushed to my master branch, sorry about that.)