### PR TITLE
Extracted the HTML format logic to the HtmlFormatter

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
@@ -1,0 +1,52 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.text.Html;
+import android.text.Html.ImageGetter;
+import android.text.Spanned;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class HtmlFormatter {
+
+    private HtmlFormatter() {
+    }
+
+    public static Spanned formatHtml(@NonNull HtmlFormatterBuilder builder) {
+        return formatHtml(builder.getHtml(), builder.getImageGetter(), builder.getClickableTableSpan(), builder.getDrawTableLinkSpan(), builder.getIndent(), builder.isRemoveTrailingWhiteSpace());
+    }
+
+    public static Spanned formatHtml(@Nullable String html, ImageGetter imageGetter, ClickableTableSpan clickableTableSpan, DrawTableLinkSpan drawTableLinkSpan, float indent, boolean removeTrailingWhiteSpace) {
+        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
+        htmlTagHandler.setClickableTableSpan(clickableTableSpan);
+        htmlTagHandler.setDrawTableLinkSpan(drawTableLinkSpan);
+        htmlTagHandler.setListIndentPx(indent);
+
+        html = htmlTagHandler.overrideTags(html);
+
+        Spanned formattedHtml;
+        if (removeTrailingWhiteSpace) {
+            formattedHtml = removeHtmlBottomPadding(Html.fromHtml(html, imageGetter, htmlTagHandler));
+        } else {
+            formattedHtml = Html.fromHtml(html, imageGetter, htmlTagHandler);
+        }
+
+        return formattedHtml;
+    }
+
+    /**
+     * Html.fromHtml sometimes adds extra space at the bottom.
+     * This methods removes this space again.
+     * See https://github.com/SufficientlySecure/html-textview/issues/19
+     */
+    @Nullable
+    private static Spanned removeHtmlBottomPadding(@Nullable Spanned text) {
+        if (text == null) {
+            return null;
+        }
+
+        while (text.length() > 0 && text.charAt(text.length() - 1) == '\n') {
+            text = (Spanned) text.subSequence(0, text.length() - 1);
+        }
+        return text;
+    }
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatterBuilder.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatterBuilder.java
@@ -1,0 +1,68 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.text.Html.ImageGetter;
+import androidx.annotation.Nullable;
+
+public class HtmlFormatterBuilder {
+
+    private String html;
+    private ImageGetter imageGetter;
+    private ClickableTableSpan clickableTableSpan;
+    private DrawTableLinkSpan drawTableLinkSpan;
+    private float indent = 24.0f;
+    private boolean removeTrailingWhiteSpace = true;
+
+    public String getHtml() {
+        return html;
+    }
+
+    public ImageGetter getImageGetter() {
+        return imageGetter;
+    }
+
+    public ClickableTableSpan getClickableTableSpan() {
+        return clickableTableSpan;
+    }
+
+    public DrawTableLinkSpan getDrawTableLinkSpan() {
+        return drawTableLinkSpan;
+    }
+
+    public float getIndent() {
+        return indent;
+    }
+
+    public boolean isRemoveTrailingWhiteSpace() {
+        return removeTrailingWhiteSpace;
+    }
+
+    public HtmlFormatterBuilder setHtml(@Nullable final String html) {
+        this.html = html;
+        return this;
+    }
+
+    public HtmlFormatterBuilder setImageGetter(@Nullable final ImageGetter imageGetter) {
+        this.imageGetter = imageGetter;
+        return this;
+    }
+
+    public HtmlFormatterBuilder setClickableTableSpan(@Nullable final ClickableTableSpan clickableTableSpan) {
+        this.clickableTableSpan = clickableTableSpan;
+        return this;
+    }
+
+    public HtmlFormatterBuilder setDrawTableLinkSpan(@Nullable final DrawTableLinkSpan drawTableLinkSpan) {
+        this.drawTableLinkSpan = drawTableLinkSpan;
+        return this;
+    }
+
+    public HtmlFormatterBuilder setIndent(final float indent) {
+        this.indent = indent;
+        return this;
+    }
+
+    public HtmlFormatterBuilder setRemoveTrailingWhiteSpace(final boolean removeTrailingWhiteSpace) {
+        this.removeTrailingWhiteSpace = removeTrailingWhiteSpace;
+        return this;
+    }
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlResImageGetter.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlResImageGetter.java
@@ -21,20 +21,19 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.Html;
 import android.util.Log;
-import android.widget.TextView;
+import androidx.annotation.NonNull;
 
 /**
  * Copied from http://stackoverflow.com/a/22298833
  */
 public class HtmlResImageGetter implements Html.ImageGetter {
-    TextView container;
+    private Context context;
 
-    public HtmlResImageGetter(TextView textView) {
-        this.container = textView;
+    public HtmlResImageGetter(@NonNull Context context) {
+        this.context = context;
     }
 
     public Drawable getDrawable(String source) {
-        Context context = container.getContext();
         int id = context.getResources().getIdentifier(source, "drawable", context.getPackageName());
 
         if (id == 0) {

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -26,7 +26,6 @@ import android.text.Html;
 import android.text.Layout;
 import android.text.Spannable;
 import android.text.Spanned;
-import android.text.TextPaint;
 import android.text.style.AlignmentSpan;
 import android.text.style.BulletSpan;
 import android.text.style.LeadingMarginSpan;
@@ -46,10 +45,8 @@ public class HtmlTagHandler implements Html.TagHandler {
     public static final String UNORDERED_LIST = "HTML_TEXTVIEW_ESCAPED_UL_TAG";
     public static final String ORDERED_LIST = "HTML_TEXTVIEW_ESCAPED_OL_TAG";
     public static final String LIST_ITEM = "HTML_TEXTVIEW_ESCAPED_LI_TAG";
-    private final TextPaint mTextPaint;
 
-    public HtmlTagHandler(TextPaint textPaint) {
-        mTextPaint = textPaint;
+    public HtmlTagHandler() {
     }
 
     /**

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -91,18 +91,7 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      *                    HtmlLocalImageGetter and HtmlRemoteImageGetter
      */
     public void setHtml(@NonNull String html, @Nullable Html.ImageGetter imageGetter) {
-        final HtmlTagHandler htmlTagHandler = new HtmlTagHandler(getPaint());
-        htmlTagHandler.setClickableTableSpan(clickableTableSpan);
-        htmlTagHandler.setDrawTableLinkSpan(drawTableLinkSpan);
-        htmlTagHandler.setListIndentPx(indent);
-
-        html = htmlTagHandler.overrideTags(html);
-
-        if (removeTrailingWhiteSpace) {
-            setText(removeHtmlBottomPadding(Html.fromHtml(html, imageGetter, htmlTagHandler)));
-        } else {
-            setText(Html.fromHtml(html, imageGetter, htmlTagHandler));
-        }
+        setText(HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, indent, removeTrailingWhiteSpace));
 
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());
@@ -157,25 +146,8 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      * http://stackoverflow.com/questions/309424/read-convert-an-inputstream-to-a-string
      */
     @NonNull
-    static private String convertStreamToString(@NonNull InputStream is) {
+    private static String convertStreamToString(@NonNull InputStream is) {
         Scanner s = new Scanner(is).useDelimiter("\\A");
         return s.hasNext() ? s.next() : "";
-    }
-
-    /**
-     * Html.fromHtml sometimes adds extra space at the bottom.
-     * This methods removes this space again.
-     * See https://github.com/SufficientlySecure/html-textview/issues/19
-     */
-    @Nullable
-    static private CharSequence removeHtmlBottomPadding(@Nullable CharSequence text) {
-        if (text == null) {
-            return null;
-        }
-
-        while (text.length() > 0 && text.charAt(text.length() - 1) == '\n') {
-            text = text.subSequence(0, text.length() - 1);
-        }
-        return text;
     }
 }

--- a/README.md
+++ b/README.md
@@ -68,6 +68,25 @@ HtmlTextView htmlTextView = (HtmlTextView) view.findViewById(R.id.html_text);
 htmlTextView.setHtml(R.raw.help, new HtmlHttpImageGetter(htmlTextView));
 ```
 
+or
+
+
+```java
+<TextView
+    android:id="@+id/html_text"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:textAppearance="@android:style/TextAppearance.Small" />
+```
+
+```java
+TextView htmlTextView = (TextView) view.findViewById(R.id.html_text);
+
+// loads html from string and displays cat_pic.png from the app's drawable folder
+Spanned formattedHtml = HtmlFormatter.formatHtml(new HtmlFormatterBuilder().setHtml("<h2>Hello wold</h2><ul><li>cats</li><li>dogs</li></ul><img src=\"cat_pic\"/>").setImageGetter(new HtmlResImageGetter(htmlTextView.getContext())));
+htmlTextView.setText(formattedHtml);
+```
+
 ## Supported HTML tags
 
 ### Tags supported by Android ([history of Html class](https://github.com/android/platform_frameworks_base/commits/master/core/java/android/text/Html.java))

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/DataBindingExampleActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/DataBindingExampleActivity.java
@@ -60,7 +60,7 @@ public class DataBindingExampleActivity extends Activity {
      */
     @BindingAdapter({"html"})
     public static void displayHtml(HtmlTextView view, @Nullable String html) {
-        view.setHtml(html, new HtmlResImageGetter(view));
+        view.setHtml(html, new HtmlResImageGetter(view.getContext()));
     }
 
     /**

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -67,7 +67,7 @@ public class MainActivity extends Activity {
         getWindowManager().getDefaultDisplay().getMetrics(metrics);
         textView.setListIndentPx(metrics.density * 10);
 
-        textView.setHtml(R.raw.example, new HtmlResImageGetter(textView));
+        textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
     }
 
     @Override


### PR DESCRIPTION
This allows to format an HTML string without having to use an HtmlTextView in the layout.

Also this allows to customize the html before passing it to the TextView, for example one could change all BulletSpans with its own implementation.

```
Spanned formattedHtml = HtmlFormatter.formatHtml(new HtmlFormatterBuilder().setHtml("<h2>Hello wold</h2><ul><li>cats</li><li>dogs</li></ul><img src=\"cat_pic\"/>").setImageGetter(new HtmlResImageGetter(htmlTextView.getContext())));
SpannableStringBuilder textSpanBuilder = new SpannableStringBuilder(formattedHtml);
final BulletSpan[] bulletSpans = textSpanBuilder.getSpans(0, text.length(), BulletSpan.class);
for (final BulletSpan bulletSpan : bulletSpans) {
  int start = text.getSpanStart(bulletSpan);
  int end = text.getSpanEnd(bulletSpan);
  textSpanBuilder.removeSpan(bulletSpan);
  textSpanBuilder.setSpan(
    new FixedBulletSpan(bulletSpan.getGapWidth()),
    start,
    end,
    Spanned.SPAN_INCLUSIVE_EXCLUSIVE
  );
}
```

HtmlFormatterBuilder parameter uses the builder pattern.

Removed unused HtmlTagHandler#mTextPaint
Replace HtmlResImageGetter#container TextView with Context