### PR TITLE
support for a tag click listener

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
@@ -17,6 +17,7 @@ package org.sufficientlysecure.htmltextview;
 import android.text.Html;
 import android.text.Html.ImageGetter;
 import android.text.Spanned;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -26,22 +27,23 @@ public class HtmlFormatter {
     }
 
     public static Spanned formatHtml(@NonNull HtmlFormatterBuilder builder) {
-        return formatHtml(builder.getHtml(), builder.getImageGetter(), builder.getClickableTableSpan(), builder.getDrawTableLinkSpan(), builder.getIndent(), builder.isRemoveTrailingWhiteSpace());
+        return formatHtml(builder.getHtml(), builder.getImageGetter(), builder.getClickableTableSpan(), builder.getDrawTableLinkSpan(), builder.getOnClickATagListener(), builder.getIndent(), builder.isRemoveTrailingWhiteSpace());
     }
 
-    public static Spanned formatHtml(@Nullable String html, ImageGetter imageGetter, ClickableTableSpan clickableTableSpan, DrawTableLinkSpan drawTableLinkSpan, float indent, boolean removeTrailingWhiteSpace) {
+    public static Spanned formatHtml(@Nullable String html, ImageGetter imageGetter, ClickableTableSpan clickableTableSpan, DrawTableLinkSpan drawTableLinkSpan, OnClickATagListener onClickATagListener, float indent, boolean removeTrailingWhiteSpace) {
         final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
         htmlTagHandler.setClickableTableSpan(clickableTableSpan);
         htmlTagHandler.setDrawTableLinkSpan(drawTableLinkSpan);
+        htmlTagHandler.setOnClickATagListener(onClickATagListener);
         htmlTagHandler.setListIndentPx(indent);
 
         html = htmlTagHandler.overrideTags(html);
 
         Spanned formattedHtml;
         if (removeTrailingWhiteSpace) {
-            formattedHtml = removeHtmlBottomPadding(Html.fromHtml(html, imageGetter, htmlTagHandler));
+            formattedHtml = removeHtmlBottomPadding(Html.fromHtml(html, imageGetter, new WrapperContentHandler(htmlTagHandler)));
         } else {
-            formattedHtml = Html.fromHtml(html, imageGetter, htmlTagHandler);
+            formattedHtml = Html.fromHtml(html, imageGetter, new WrapperContentHandler(htmlTagHandler));
         }
 
         return formattedHtml;

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatterBuilder.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatterBuilder.java
@@ -23,6 +23,7 @@ public class HtmlFormatterBuilder {
     private ImageGetter imageGetter;
     private ClickableTableSpan clickableTableSpan;
     private DrawTableLinkSpan drawTableLinkSpan;
+    private OnClickATagListener onClickATagListener;
     private float indent = 24.0f;
     private boolean removeTrailingWhiteSpace = true;
 
@@ -40,6 +41,10 @@ public class HtmlFormatterBuilder {
 
     public DrawTableLinkSpan getDrawTableLinkSpan() {
         return drawTableLinkSpan;
+    }
+
+    public OnClickATagListener getOnClickATagListener() {
+        return onClickATagListener;
     }
 
     public float getIndent() {
@@ -68,6 +73,10 @@ public class HtmlFormatterBuilder {
     public HtmlFormatterBuilder setDrawTableLinkSpan(@Nullable final DrawTableLinkSpan drawTableLinkSpan) {
         this.drawTableLinkSpan = drawTableLinkSpan;
         return this;
+    }
+
+    public void setOnClickATagListener(OnClickATagListener onClickATagListener) {
+        this.onClickATagListener = onClickATagListener;
     }
 
     public HtmlFormatterBuilder setIndent(final float indent) {

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -17,13 +17,12 @@
 package org.sufficientlysecure.htmltextview;
 
 import android.content.Context;
+import android.text.Html;
+import android.util.AttributeSet;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
-
-import android.text.Html;
-import android.util.AttributeSet;
 
 import java.io.InputStream;
 import java.util.Scanner;
@@ -37,6 +36,8 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
     private ClickableTableSpan clickableTableSpan;
     @Nullable
     private DrawTableLinkSpan drawTableLinkSpan;
+    @Nullable
+    private OnClickATagListener onClickATagListener;
     private float indent = 24.0f; // Default to 24px.
 
     private boolean removeTrailingWhiteSpace = true;
@@ -91,7 +92,7 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      *                    HtmlLocalImageGetter and HtmlRemoteImageGetter
      */
     public void setHtml(@NonNull String html, @Nullable Html.ImageGetter imageGetter) {
-        setText(HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, indent, removeTrailingWhiteSpace));
+        setText(HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, onClickATagListener,indent, removeTrailingWhiteSpace));
 
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());
@@ -130,6 +131,10 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
 
     public void setDrawTableLinkSpan(@Nullable DrawTableLinkSpan drawTableLinkSpan) {
         this.drawTableLinkSpan = drawTableLinkSpan;
+    }
+
+    public void setOnClickATagListener(@Nullable OnClickATagListener onClickATagListener) {
+        this.onClickATagListener = onClickATagListener;
     }
 
     /**

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
@@ -1,0 +1,13 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+/**
+ * This listener can define what happens when the a tag is clicked
+ */
+public interface OnClickATagListener {
+    void onClick(View widget, @Nullable String href);
+
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperContentHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperContentHandler.java
@@ -2,7 +2,6 @@ package org.sufficientlysecure.htmltextview;
 
 import android.text.Editable;
 import android.text.Html;
-import android.util.Log;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -21,7 +20,6 @@ public class WrapperContentHandler implements ContentHandler, Html.TagHandler {
 
     @Override
     public void handleTag(boolean opening, String tag, Editable output, XMLReader xmlReader) {
-        Log.d("------->", "handleTag--->" + opening + "-->" + tag + "--->" + output);
         if (mContentHandler == null) {
             mSpannableStringBuilder = output;
             mContentHandler = xmlReader.getContentHandler();
@@ -56,7 +54,6 @@ public class WrapperContentHandler implements ContentHandler, Html.TagHandler {
 
     @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        Log.d("------->", "startElement--->" + localName + "-->" + qName);
         if (!mTagHandler.handleTag(true, localName, mSpannableStringBuilder, attributes)) {
             mContentHandler.startElement(uri, localName, qName, attributes);
         }
@@ -65,7 +62,6 @@ public class WrapperContentHandler implements ContentHandler, Html.TagHandler {
 
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        Log.d("------->", "endElement--->" + localName + "-->" + qName);
         if (!mTagHandler.handleTag(false, localName, mSpannableStringBuilder, null)) {
             mContentHandler.endElement(uri, localName, qName);
         }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperContentHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperContentHandler.java
@@ -1,0 +1,94 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.text.Editable;
+import android.text.Html;
+import android.util.Log;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.Locator;
+import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
+
+public class WrapperContentHandler implements ContentHandler, Html.TagHandler {
+    private ContentHandler mContentHandler;
+    private WrapperTagHandler mTagHandler;
+    private Editable mSpannableStringBuilder;
+
+    public WrapperContentHandler(WrapperTagHandler tagHandler) {
+        this.mTagHandler = tagHandler;
+    }
+
+    @Override
+    public void handleTag(boolean opening, String tag, Editable output, XMLReader xmlReader) {
+        Log.d("------->", "handleTag--->" + opening + "-->" + tag + "--->" + output);
+        if (mContentHandler == null) {
+            mSpannableStringBuilder = output;
+            mContentHandler = xmlReader.getContentHandler();
+            xmlReader.setContentHandler(this);
+        }
+    }
+
+    @Override
+    public void setDocumentLocator(Locator locator) {
+        mContentHandler.setDocumentLocator(locator);
+    }
+
+    @Override
+    public void startDocument() throws SAXException {
+        mContentHandler.startDocument();
+    }
+
+    @Override
+    public void endDocument() throws SAXException {
+        mContentHandler.endDocument();
+    }
+
+    @Override
+    public void startPrefixMapping(String prefix, String uri) throws SAXException {
+        mContentHandler.startPrefixMapping(prefix, uri);
+    }
+
+    @Override
+    public void endPrefixMapping(String prefix) throws SAXException {
+        mContentHandler.endPrefixMapping(prefix);
+    }
+
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        Log.d("------->", "startElement--->" + localName + "-->" + qName);
+        if (!mTagHandler.handleTag(true, localName, mSpannableStringBuilder, attributes)) {
+            mContentHandler.startElement(uri, localName, qName, attributes);
+        }
+    }
+
+
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        Log.d("------->", "endElement--->" + localName + "-->" + qName);
+        if (!mTagHandler.handleTag(false, localName, mSpannableStringBuilder, null)) {
+            mContentHandler.endElement(uri, localName, qName);
+        }
+    }
+
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        mContentHandler.characters(ch, start, length);
+    }
+
+    @Override
+    public void ignorableWhitespace(char[] ch, int start, int length) throws SAXException {
+        mContentHandler.ignorableWhitespace(ch, start, length);
+    }
+
+    @Override
+    public void processingInstruction(String target, String data) throws SAXException {
+        mContentHandler.processingInstruction(target, data);
+    }
+
+    @Override
+    public void skippedEntity(String name) throws SAXException {
+        mContentHandler.skippedEntity(name);
+    }
+
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/WrapperTagHandler.java
@@ -1,0 +1,11 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.text.Editable;
+
+import androidx.annotation.Nullable;
+
+import org.xml.sax.Attributes;
+
+public interface WrapperTagHandler {
+    boolean handleTag(boolean opening, String tag, Editable output, @Nullable Attributes attributes);
+}

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ HtmlTextView now supports HTML tables (to a limited extent) by condensing the te
 
 Take a look at the project's [sample app](https://github.com/SufficientlySecure/html-textview/blob/master/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java) for an example.
 
+### Support for A tag click listener
+```
+textView.setOnClickATagListener(new OnClickATagListener() {
+
+    @Override
+    public void onClick(View widget, @Nullable String href) {
+        Toast.makeText(MainActivity.this, href, Toast.LENGTH_SHORT).show();
+    }
+});
+```
+
+
 We recognize the standard table tags:
 
 * ``<table>``

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -23,11 +23,15 @@ import android.util.DisplayMetrics;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
+
+import androidx.annotation.Nullable;
 
 import org.sufficientlysecure.htmltextview.ClickableTableSpan;
 import org.sufficientlysecure.htmltextview.DrawTableLinkSpan;
 import org.sufficientlysecure.htmltextview.HtmlResImageGetter;
 import org.sufficientlysecure.htmltextview.HtmlTextView;
+import org.sufficientlysecure.htmltextview.OnClickATagListener;
 
 import static org.sufficientlysecure.htmltextview.example.WebViewActivity.EXTRA_TABLE_HTML;
 
@@ -66,6 +70,15 @@ public class MainActivity extends Activity {
         DisplayMetrics metrics = new DisplayMetrics();
         getWindowManager().getDefaultDisplay().getMetrics(metrics);
         textView.setListIndentPx(metrics.density * 10);
+
+        // a tag click listener
+textView.setOnClickATagListener(new OnClickATagListener() {
+
+    @Override
+    public void onClick(View widget, @Nullable String href) {
+        Toast.makeText(MainActivity.this, href, Toast.LENGTH_SHORT).show();
+    }
+});
 
         textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
     }

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -72,13 +72,15 @@ public class MainActivity extends Activity {
         textView.setListIndentPx(metrics.density * 10);
 
         // a tag click listener
-textView.setOnClickATagListener(new OnClickATagListener() {
+        textView.setOnClickATagListener(new OnClickATagListener() {
 
-    @Override
-    public void onClick(View widget, @Nullable String href) {
-        Toast.makeText(MainActivity.this, href, Toast.LENGTH_SHORT).show();
-    }
-});
+            @Override
+            public void onClick(View widget, @Nullable String href) {
+                final Toast toast = Toast.makeText(MainActivity.this, null, Toast.LENGTH_SHORT);
+                toast.setText(href);
+                toast.show();
+            }
+        });
 
         textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
     }


### PR DESCRIPTION
Hi, I made some adjustments based on the current `HtmlTagHandler` to support the custom click event of the a tag, I believe not only I have this demand.
[#138](https://github.com/SufficientlySecure/html-textview/issues/138) [#134](https://github.com/SufficientlySecure/html-textview/issues/134) [#17](https://github.com/SufficientlySecure/html-textview/issues/17) [#87](https://github.com/SufficientlySecure/html-textview/issues/87)

<Img src="https://user-images.githubusercontent.com/17588779/71170688-d3ad2500-2296-11ea-9839-6ef0538d38dc.gif" width="300"/>

Not only that, `handleTag` can now get attributes, so it can do more.
```
public boolean handleTag(boolean opening, String tag, Editable output, Attributes attributes) {
        ...
}
```
