### PR TITLE
added blockquote styling feature

### DIFF
--- a/HtmlTextView/build.gradle
+++ b/HtmlTextView/build.gradle
@@ -22,4 +22,5 @@ publish {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
+
  }

--- a/HtmlTextView/build.gradle
+++ b/HtmlTextView/build.gradle
@@ -22,4 +22,4 @@ publish {
 
 dependencies {
     implementation 'androidx.annotation:annotation:1.1.0'
-}
+ }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DesignQuoteSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DesignQuoteSpan.java
@@ -5,11 +5,8 @@ import android.graphics.Paint;
 import android.text.Layout;
 import android.text.style.LeadingMarginSpan;
 import android.text.style.LineBackgroundSpan;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
-
-import static org.sufficientlysecure.htmltextview.HtmlTextView.TAG;
 
 public class DesignQuoteSpan implements LeadingMarginSpan, LineBackgroundSpan {
 
@@ -24,7 +21,6 @@ public class DesignQuoteSpan implements LeadingMarginSpan, LineBackgroundSpan {
         this.stripColor=stripColor;
         this.stripeWidth=stripWidth;
         this.gap=gap;
-        Log.d(TAG, "DesignQuoteSpanClass: Called");
 
     }
 
@@ -46,7 +42,6 @@ public class DesignQuoteSpan implements LeadingMarginSpan, LineBackgroundSpan {
                                   int end,
                                   boolean first,
                                   Layout layout) {
-        Log.d(TAG, "drawLeadingMargin: Called");
 
         Paint.Style style=p.getStyle();
         int paintColor=p.getColor();
@@ -70,7 +65,6 @@ public class DesignQuoteSpan implements LeadingMarginSpan, LineBackgroundSpan {
                                int start,
                                int end,
                                int lineNumber) {
-        Log.d(TAG, "drawBackground: Called");
         int paintColor=paint.getColor();
         paint.setColor(backgroundColor);
         canvas.drawRect((float)left,(float)top,(float)right,(float)bottom,paint);

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DesignQuoteSpan.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/DesignQuoteSpan.java
@@ -1,0 +1,79 @@
+package org.sufficientlysecure.htmltextview;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.text.Layout;
+import android.text.style.LeadingMarginSpan;
+import android.text.style.LineBackgroundSpan;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import static org.sufficientlysecure.htmltextview.HtmlTextView.TAG;
+
+public class DesignQuoteSpan implements LeadingMarginSpan, LineBackgroundSpan {
+
+    private int backgroundColor,stripColor;
+    private float stripeWidth,gap;
+    DesignQuoteSpan(int backgroundColor,
+                    int stripColor,
+                    float stripWidth,
+                    float gap){
+
+        this.backgroundColor=backgroundColor;
+        this.stripColor=stripColor;
+        this.stripeWidth=stripWidth;
+        this.gap=gap;
+        Log.d(TAG, "DesignQuoteSpanClass: Called");
+
+    }
+
+    @Override
+    public int getLeadingMargin(boolean first) {
+        return (int)(stripeWidth + gap);
+    }
+
+    @Override
+    public void drawLeadingMargin(Canvas c,
+                                  Paint p,
+                                  int x,
+                                  int dir,
+                                  int top,
+                                  int baseline,
+                                  int bottom,
+                                  CharSequence text,
+                                  int start,
+                                  int end,
+                                  boolean first,
+                                  Layout layout) {
+        Log.d(TAG, "drawLeadingMargin: Called");
+
+        Paint.Style style=p.getStyle();
+        int paintColor=p.getColor();
+        p.setStyle(Paint.Style.FILL);
+        p.setColor(stripColor);
+        c.drawRect((float)x,(float)top,x+dir * stripeWidth,(float)bottom,p);
+        p.setStyle(style);
+        p.setColor(paintColor);
+
+    }
+
+    @Override
+    public void drawBackground(@NonNull Canvas canvas,
+                               @NonNull Paint paint,
+                               int left,
+                               int right,
+                               int top,
+                               int baseline,
+                               int bottom,
+                               @NonNull CharSequence text,
+                               int start,
+                               int end,
+                               int lineNumber) {
+        Log.d(TAG, "drawBackground: Called");
+        int paintColor=paint.getColor();
+        paint.setColor(backgroundColor);
+        canvas.drawRect((float)left,(float)top,(float)right,(float)bottom,paint);
+        paint.setColor(paintColor);
+    }
+}

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -18,7 +18,11 @@ package org.sufficientlysecure.htmltextview;
 
 import android.content.Context;
 import android.text.Html;
+import android.text.Spannable;
+import android.text.Spanned;
+import android.text.style.QuoteSpan;
 import android.util.AttributeSet;
+import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -31,7 +35,10 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
 
     public static final String TAG = "HtmlTextView";
     public static final boolean DEBUG = false;
-
+    public int blockQuoteBackgroundColor= getResources().getColor(R.color.White);
+    public int blockQuoteStripColor= getResources().getColor(R.color.black);
+    public float blockQuoteStripWidth =10F;
+    public float blockQuoteGap=20F;
     @Nullable
     private ClickableTableSpan clickableTableSpan;
     @Nullable
@@ -92,7 +99,10 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      *                    HtmlLocalImageGetter and HtmlRemoteImageGetter
      */
     public void setHtml(@NonNull String html, @Nullable Html.ImageGetter imageGetter) {
-        setText(HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, onClickATagListener,indent, removeTrailingWhiteSpace));
+
+        Spanned styledText = HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, onClickATagListener, indent, removeTrailingWhiteSpace);
+        replaceQuoteSpans(styledText);
+        setText(styledText);
 
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());
@@ -155,4 +165,28 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
         Scanner s = new Scanner(is).useDelimiter("\\A");
         return s.hasNext() ? s.next() : "";
     }
+
+
+    private void replaceQuoteSpans(Spanned spanned) {
+
+        Spannable spannable = (Spannable) spanned;
+        QuoteSpan[] quoteSpans = spannable.getSpans(0, spannable.length() - 1, QuoteSpan.class);
+        Log.d(TAG, "replaceQuoteSpans: " + spannable);
+        for (QuoteSpan quoteSpan : quoteSpans) {
+            int start = spannable.getSpanStart(quoteSpan);
+            int end = spannable.getSpanEnd(quoteSpan);
+            int flags = spannable.getSpanFlags(quoteSpan);
+            spannable.removeSpan(quoteSpan);
+            spannable.setSpan(new DesignQuoteSpan(
+                            blockQuoteBackgroundColor,
+                            blockQuoteStripColor,
+                            blockQuoteStripWidth,
+                            blockQuoteGap),
+                    start,
+                    end,
+                    flags);
+        }
+    }
+
+
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -22,7 +22,6 @@ import android.text.Spannable;
 import android.text.Spanned;
 import android.text.style.QuoteSpan;
 import android.util.AttributeSet;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -171,7 +170,6 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
 
         Spannable spannable = (Spannable) spanned;
         QuoteSpan[] quoteSpans = spannable.getSpans(0, spannable.length() - 1, QuoteSpan.class);
-        Log.d(TAG, "replaceQuoteSpans: " + spannable);
         for (QuoteSpan quoteSpan : quoteSpans) {
             int start = spannable.getSpanStart(quoteSpan);
             int end = spannable.getSpanEnd(quoteSpan);

--- a/HtmlTextView/src/main/res/values/colors.xml
+++ b/HtmlTextView/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="black">#000000</color>
+    <color name="White">#ffff</color>
+</resources>

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -18,5 +18,5 @@ android {
 
 dependencies {
     implementation project(':HtmlTextView')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
 }

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/DataBindingExampleActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/DataBindingExampleActivity.java
@@ -16,10 +16,11 @@
 package org.sufficientlysecure.htmltextview.example;
 
 import android.app.Activity;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
 import androidx.databinding.BindingAdapter;
 import androidx.databinding.DataBindingUtil;
-import android.os.Bundle;
-import androidx.annotation.Nullable;
 
 import org.sufficientlysecure.htmltextview.DrawTableLinkSpan;
 import org.sufficientlysecure.htmltextview.HtmlResImageGetter;

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -81,6 +81,8 @@ public class MainActivity extends Activity {
                 toast.show();
             }
         });
+        textView.blockQuoteBackgroundColor=getResources().getColor(R.color.whitish);
+        textView.blockQuoteStripColor=getResources().getColor(R.color.blue);
 
         textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
     }

--- a/example/src/main/res/raw/example.html
+++ b/example/src/main/res/raw/example.html
@@ -116,7 +116,9 @@ when using a normal TextView, but our implementation should workaround that bug.
     aliquam convallis dapibus. Aenean suscipit, orci id elementum vehicula, odio arcu fringilla massa,
     vel imperdiet augue est non mi.
 </p>
-<p>
+<blockquote>
+
+    <h4>This text is in blockquote TAG</h4>
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam ut eros sed arcu auctor tincidunt
     id sit amet elit. Mauris in faucibus neque. Suspendisse facilisis urna nec nisi convallis tincidunt.
     Mauris at elit et arcu viverra auctor. Nullam et arcu ultricies, iaculis dolor efficitur, tristique eros.
@@ -127,7 +129,7 @@ when using a normal TextView, but our implementation should workaround that bug.
     Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vestibulum
     aliquam convallis dapibus. Aenean suscipit, orci id elementum vehicula, odio arcu fringilla massa,
     vel imperdiet augue est non mi.
-</p>
+</blockquote>
 <p>
     Android will add extra space at the bottom of the textView by default fromHtml,
     use <code>setRemoveFromHtmlSpace(true)</code> on your <b>HtmlTextView</b>

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="blue">#03DAC5</color>
+    <color name="whitish">#ccc</color>
+</resources>


### PR DESCRIPTION
Users can now style blockquote tags(set background color,set strip color, set strip width), instead of living with the default blue ugly line.
To change background color
`textView.blockQuoteBackgroundColor=getResources().getColor(R.color.whitish);`

To change strip color
` textView.blockQuoteStripColor=getResources().getColor(R.color.blue);`


**Difference**
![difference](https://user-images.githubusercontent.com/30768018/91086701-e6b99580-e66c-11ea-9714-3c73ab044eaa.png)
