### PR TITLE
A tag click enhancements

### DIFF
--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlFormatter.java
@@ -26,15 +26,27 @@ public class HtmlFormatter {
     private HtmlFormatter() {
     }
 
-    public static Spanned formatHtml(@NonNull HtmlFormatterBuilder builder) {
-        return formatHtml(builder.getHtml(), builder.getImageGetter(), builder.getClickableTableSpan(), builder.getDrawTableLinkSpan(), builder.getOnClickATagListener(), builder.getIndent(), builder.isRemoveTrailingWhiteSpace());
+    public static Spanned formatHtml(@NonNull final HtmlFormatterBuilder builder) {
+        return formatHtml(
+            builder.getHtml(), builder.getImageGetter(), builder.getClickableTableSpan(),
+            builder.getDrawTableLinkSpan(), new TagClickListenerProvider() {
+                @Override public OnClickATagListener provideTagClickListener() {
+                    return builder.getOnClickATagListener();
+                }
+            }, builder.getIndent(),
+            builder.isRemoveTrailingWhiteSpace()
+        );
     }
 
-    public static Spanned formatHtml(@Nullable String html, ImageGetter imageGetter, ClickableTableSpan clickableTableSpan, DrawTableLinkSpan drawTableLinkSpan, OnClickATagListener onClickATagListener, float indent, boolean removeTrailingWhiteSpace) {
+    interface TagClickListenerProvider {
+        OnClickATagListener provideTagClickListener();
+    }
+
+    public static Spanned formatHtml(@Nullable String html, ImageGetter imageGetter, ClickableTableSpan clickableTableSpan, DrawTableLinkSpan drawTableLinkSpan, TagClickListenerProvider tagClickListenerProvider, float indent, boolean removeTrailingWhiteSpace) {
         final HtmlTagHandler htmlTagHandler = new HtmlTagHandler();
         htmlTagHandler.setClickableTableSpan(clickableTableSpan);
         htmlTagHandler.setDrawTableLinkSpan(drawTableLinkSpan);
-        htmlTagHandler.setOnClickATagListener(onClickATagListener);
+        htmlTagHandler.setOnClickATagListenerProvider(tagClickListenerProvider);
         htmlTagHandler.setListIndentPx(indent);
 
         html = htmlTagHandler.overrideTags(html);

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -32,12 +32,9 @@ import android.text.style.TypefaceSpan;
 import android.text.style.URLSpan;
 import android.util.Log;
 import android.view.View;
-
 import androidx.annotation.Nullable;
-
-import org.xml.sax.Attributes;
-
 import java.util.Stack;
+import org.xml.sax.Attributes;
 
 /**
  * Some parts of this code are based on android.text.Html
@@ -117,7 +114,7 @@ public class HtmlTagHandler implements WrapperTagHandler {
     private static final BulletSpan defaultBullet = new BulletSpan(defaultIndent);
     private ClickableTableSpan clickableTableSpan;
     private DrawTableLinkSpan drawTableLinkSpan;
-    private OnClickATagListener onClickATagListener;
+    private HtmlFormatter.TagClickListenerProvider onClickATagListenerProvider;
 
     private static class Ul {
     }
@@ -273,8 +270,9 @@ public class HtmlTagHandler implements WrapperTagHandler {
                 end(output, A.class, false, new URLSpan(href) {
                     @Override
                     public void onClick(View widget) {
-                        if (onClickATagListener != null) {
-                            onClickATagListener.onClick(widget, spannedText, getURL());
+                        if (onClickATagListenerProvider != null) {
+                            onClickATagListenerProvider.provideTagClickListener()
+                                                       .onClick(widget, spannedText, getURL());
                         }
                         super.onClick(widget);
                     }
@@ -431,7 +429,7 @@ public class HtmlTagHandler implements WrapperTagHandler {
         this.drawTableLinkSpan = drawTableLinkSpan;
     }
 
-    public void setOnClickATagListener(OnClickATagListener onClickATagListener) {
-        this.onClickATagListener = onClickATagListener;
+    public void setOnClickATagListenerProvider(HtmlFormatter.TagClickListenerProvider onClickATagListenerProvider) {
+        this.onClickATagListenerProvider = onClickATagListenerProvider;
     }
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -271,10 +271,13 @@ public class HtmlTagHandler implements WrapperTagHandler {
                     @Override
                     public void onClick(View widget) {
                         if (onClickATagListenerProvider != null) {
-                            onClickATagListenerProvider.provideTagClickListener()
-                                                       .onClick(widget, spannedText, getURL());
+                            boolean clickConsumed =
+                                onClickATagListenerProvider.provideTagClickListener()
+                                                           .onClick(widget, spannedText, getURL());
+                            if (!clickConsumed) {
+                                super.onClick(widget);
+                            }
                         }
-                        super.onClick(widget);
                     }
                 });
             } else if (tag.equalsIgnoreCase("code")) {

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTagHandler.java
@@ -126,9 +126,11 @@ public class HtmlTagHandler implements WrapperTagHandler {
     }
 
     private static class A {
+        private String text;
         private String href;
 
-        private A(String href) {
+        private A(String text, String href) {
+            this.text = text;
             this.href = href;
         }
     }
@@ -182,7 +184,7 @@ public class HtmlTagHandler implements WrapperTagHandler {
                 }
             } else if (tag.equalsIgnoreCase(A_ITEM)) {
                 final String href = attributes != null ? attributes.getValue("href") : null;
-                start(output, new A(href));
+                start(output, new A(output.toString(), href));
             } else if (tag.equalsIgnoreCase("code")) {
                 start(output, new Code());
             } else if (tag.equalsIgnoreCase("center")) {
@@ -264,15 +266,17 @@ public class HtmlTagHandler implements WrapperTagHandler {
                 }
             } else if (tag.equalsIgnoreCase(A_ITEM)) {
                 final Object a = getLast(output, A.class);
+                final int spanStart = output.getSpanStart(a);
+                final int spanEnd = output.length();
                 final String href = a instanceof A ? ((A) a).href : null;
+                final String spannedText = output.subSequence(spanStart, spanEnd).toString();
                 end(output, A.class, false, new URLSpan(href) {
                     @Override
                     public void onClick(View widget) {
                         if (onClickATagListener != null) {
-                            onClickATagListener.onClick(widget, getURL());
-                        } else {
-                            super.onClick(widget);
+                            onClickATagListener.onClick(widget, spannedText, getURL());
                         }
+                        super.onClick(widget);
                     }
                 });
             } else if (tag.equalsIgnoreCase("code")) {

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/HtmlTextView.java
@@ -92,7 +92,14 @@ public class HtmlTextView extends JellyBeanSpanFixTextView {
      *                    HtmlLocalImageGetter and HtmlRemoteImageGetter
      */
     public void setHtml(@NonNull String html, @Nullable Html.ImageGetter imageGetter) {
-        setText(HtmlFormatter.formatHtml(html, imageGetter, clickableTableSpan, drawTableLinkSpan, onClickATagListener,indent, removeTrailingWhiteSpace));
+        setText(HtmlFormatter.formatHtml(
+            html, imageGetter, clickableTableSpan, drawTableLinkSpan,
+            new HtmlFormatter.TagClickListenerProvider() {
+                @Override public OnClickATagListener provideTagClickListener() {
+                    return onClickATagListener;
+                }
+            }, indent, removeTrailingWhiteSpace
+        ));
 
         // make links work
         setMovementMethod(LocalLinkMovementMethod.getInstance());

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
@@ -8,5 +8,12 @@ import androidx.annotation.Nullable;
  * This listener can define what happens when the a tag is clicked
  */
 public interface OnClickATagListener {
-    void onClick(View widget, String spannedText, @Nullable String href);
+    /**
+     * Notifies of anchor tag click events.
+     * @param widget - the {@link HtmlTextView} instance
+     * @param spannedText - the string value of the text spanned
+     * @param href - the url for the anchor tag
+     * @return indicates whether the click event has been handled
+     */
+    boolean onClick(View widget, String spannedText, @Nullable String href);
 }

--- a/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
+++ b/HtmlTextView/src/main/java/org/sufficientlysecure/htmltextview/OnClickATagListener.java
@@ -8,6 +8,5 @@ import androidx.annotation.Nullable;
  * This listener can define what happens when the a tag is clicked
  */
 public interface OnClickATagListener {
-    void onClick(View widget, @Nullable String href);
-
+    void onClick(View widget, String spannedText, @Nullable String href);
 }

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -71,18 +71,17 @@ public class MainActivity extends Activity {
         getWindowManager().getDefaultDisplay().getMetrics(metrics);
         textView.setListIndentPx(metrics.density * 10);
 
+        textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
+
         // a tag click listener
         textView.setOnClickATagListener(new OnClickATagListener() {
-
             @Override
-            public void onClick(View widget, @Nullable String href) {
+            public void onClick(View widget, String spannedText, @Nullable String href) {
                 final Toast toast = Toast.makeText(MainActivity.this, null, Toast.LENGTH_SHORT);
                 toast.setText(href);
                 toast.show();
             }
         });
-
-        textView.setHtml(R.raw.example, new HtmlResImageGetter(getBaseContext()));
     }
 
     @Override

--- a/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
+++ b/example/src/main/java/org/sufficientlysecure/htmltextview/example/MainActivity.java
@@ -76,10 +76,12 @@ public class MainActivity extends Activity {
         // a tag click listener
         textView.setOnClickATagListener(new OnClickATagListener() {
             @Override
-            public void onClick(View widget, String spannedText, @Nullable String href) {
+            public boolean onClick(View widget, String spannedText, @Nullable String href) {
                 final Toast toast = Toast.makeText(MainActivity.this, null, Toast.LENGTH_SHORT);
                 toast.setText(href);
                 toast.show();
+
+                return false;
             }
         });
     }


### PR DESCRIPTION
- Adds ability to set the A tag click listener anywhere, instead of strictly before a `setHtml` call
- Returns the spanned text in the callback
- Return true or false from the A tag click listener to indicate whether you want the click event to follow through with the movement method, or consume the click and handle the href yourself.